### PR TITLE
Dual approve proposal

### DIFF
--- a/controllers/githubController.js
+++ b/controllers/githubController.js
@@ -67,8 +67,8 @@ var gh_oauth_token = process.env.GITHUB_OAUTH_TOKEN;
             // this was probably another event that we care less about
             return res.send();
           }
-          var match = commentBody.match(/#approve\s([^\s]{80,})/);
-          if (!match || !match[1]) {
+          var approves = commentBody.match(/#approve\s[^\s]{80,}/g);
+          if (!approves) {
             // comment did not have the #approve hashtag
             return res.send();
           }
@@ -89,8 +89,9 @@ var gh_oauth_token = process.env.GITHUB_OAUTH_TOKEN;
 
             var approved = [];
 
-            for (var i = 1; i < match.length; i++) {
-              var signature = match[i];
+            for (var i = 0; i < approves.length; i++) {
+              // Remove the '#approve ' from the start of each match
+              var signature = approves[i].substring(9);
               if ((approved.indexOf(signature) == -1) && verify(sha, signature, logger)) {
                 approved.push(signature);
                 logger.log('Approved: ' + signature);

--- a/controllers/githubController.js
+++ b/controllers/githubController.js
@@ -91,7 +91,7 @@ var gh_oauth_token = process.env.GITHUB_OAUTH_TOKEN;
 
             for (var i = 1; i < match.length; i++) {
               var signature = match[i];
-              if (approved.indexOf(signature) == -1 && verify(sha, signature, logger)) {
+              if ((approved.indexOf(signature) == -1) && verify(sha, signature, logger)) {
                 approved.push(signature);
                 logger.log('Approved: ' + signature);
               } else {

--- a/controllers/githubController.js
+++ b/controllers/githubController.js
@@ -72,7 +72,6 @@ var gh_oauth_token = process.env.GITHUB_OAUTH_TOKEN;
             // comment did not have the #approve hashtag
             return res.send();
           }
-          var signature = match[1];
           getPr(prNumber, function(err, pr) {
             if (err) {
               logger.error(err);
@@ -87,7 +86,20 @@ var gh_oauth_token = process.env.GITHUB_OAUTH_TOKEN;
               logger.log('Unclean merge state');
               return end('PR is not mergeable');
             }
-            if (!verify(sha, signature, logger)) {
+
+            var approvals = 0;
+
+            for (var i = 1; i < match.length; i++) {
+              var signature = match[i];
+              if (verify(sha, signature, logger)) {
+                approvals++;
+                logger.log('Approved: ' + signature);
+              } else {
+                logger.log('Rejected: ' + signature);
+              }
+            }
+
+            if (approvals < 2) {
               logger.log('Signature verification failed');
               return end('Signature verification failed');
             }

--- a/controllers/githubController.js
+++ b/controllers/githubController.js
@@ -87,19 +87,19 @@ var gh_oauth_token = process.env.GITHUB_OAUTH_TOKEN;
               return end('PR is not mergeable');
             }
 
-            var approvals = 0;
+            var approved = [];
 
             for (var i = 1; i < match.length; i++) {
               var signature = match[i];
-              if (verify(sha, signature, logger)) {
-                approvals++;
+              if (approved.indexOf(signature) == -1 && verify(sha, signature, logger)) {
+                approved.push(signature);
                 logger.log('Approved: ' + signature);
               } else {
                 logger.log('Rejected: ' + signature);
               }
             }
 
-            if (approvals < 2) {
+            if (approved.length < 2) {
               logger.log('Signature verification failed');
               return end('Signature verification failed');
             }


### PR DESCRIPTION
With this change, one comment needs to contain two `#approval`s.

This requires a first person to sign a commit, give that signature to another user, ideally via a comment, and that other user will paste their `#approve` along with the first `#approve`.
